### PR TITLE
Performance improvements to avoid List resizing and slower disk io

### DIFF
--- a/src/main/java/craftedcart/smbworkshopexporter/LZCompressor.java
+++ b/src/main/java/craftedcart/smbworkshopexporter/LZCompressor.java
@@ -46,16 +46,16 @@ public class LZCompressor {
         }
 
         //Output data
-        List<Byte> output = new ArrayList<>();
+        List<Byte> output = new ArrayList<>(data.length);
 
         int i = 0;
         int dataSize = data.length;
         progressMax = dataSize + 8;
 
-        while (i < dataSize) {
+        //Accumulated output chunk
+        List<Byte> accum = new ArrayList<>(16);
 
-            //Accumulated output chunk
-            List<Byte> accum = new ArrayList<>();
+        while (i < dataSize) {
 
             //Process 8 literals or references at a time
             int flags = 0;
@@ -103,6 +103,7 @@ public class LZCompressor {
             //Chunk complete, add to output0
             output.add((byte) flags);
             output.addAll(accum);
+            accum.clear();
 
             progress = i;
         }

--- a/src/main/java/craftedcart/smbworkshopexporter/SMB2LZExporter.java
+++ b/src/main/java/craftedcart/smbworkshopexporter/SMB2LZExporter.java
@@ -41,7 +41,7 @@ public class SMB2LZExporter extends AbstractLzExporter {
     private static final int COLLISION_X_STEP_NUM = 16;
     private static final int COLLISION_Z_STEP_NUM = 16;
 
-    private List<Byte> outBytes = new ArrayList<>();
+    private List<Byte> outBytes = new ArrayList<>(1000000); // Around 1 MB
 
     private ModelData modelData;
     private ConfigData configData;
@@ -424,9 +424,11 @@ public class SMB2LZExporter extends AbstractLzExporter {
         FileOutputStream fos = new FileOutputStream(outFile);
         BufferedOutputStream bos = new BufferedOutputStream(fos);
 
-        for (Byte b : outBytes) {
-            bos.write(b);
+        byte[] finalByteArray = new byte[outBytes.size()];
+        for(int i = 0; i < outBytes.size(); i++){
+            finalByteArray[i] = outBytes.get(i);
         }
+        bos.write(finalByteArray);
 
         bos.close();
         fos.close();

--- a/src/main/java/craftedcart/smbworkshopexporter/SMBWorkshopExporter.java
+++ b/src/main/java/craftedcart/smbworkshopexporter/SMBWorkshopExporter.java
@@ -184,20 +184,23 @@ public class SMBWorkshopExporter {
             }
 
             try (RandomAccessFile raw = new RandomAccessFile(outputFile, "r");
-                    RandomAccessFile comp = new RandomAccessFile(outFile, "rw")) {
+                 RandomAccessFile comp = new RandomAccessFile(outFile, "rw")) {
 
-                final List<Byte> contents = new ArrayList<>();
-                while (raw.getFilePointer() < raw.length()) {
-                    contents.add(raw.readByte());
+                final byte[] byteArrayb = new byte[(int)raw.length()];
+                final Byte[] byteArray = new Byte[(int)raw.length()];
+
+                raw.read(byteArrayb);
+                for(int i = 0; i < byteArrayb.length; i++){
+                    byteArray[i] = byteArrayb[i];
                 }
 
-                final Byte[] byteArray = contents.toArray(new Byte[contents.size()]);
                 List<Byte> bl = (new LZCompressor()).compress(byteArray);
 
-                for (Byte c : bl) {
-                    comp.write(c);
+                final byte[] finalByteArray = new byte[bl.size()];
+                for(int i = 0; i < bl.size(); i++){
+                    finalByteArray[i] = bl.get(i);
                 }
-
+                comp.write(finalByteArray);
             } catch (IOException e) {
                 if (e instanceof FileNotFoundException) {
                     LogHelper.fatal(SMBWorkshopExporter.class, "LZ file not found!");

--- a/src/main/java/craftedcart/smbworkshopexporter/util/LZSSDictionary.java
+++ b/src/main/java/craftedcart/smbworkshopexporter/util/LZSSDictionary.java
@@ -21,14 +21,14 @@ public class LZSSDictionary {
 
     public LZSSDictionary() {
         //For each reference length there is one dictionary mapping substrings to dictionary offsets
-        d = new ArrayList<>();
+        d = new ArrayList<>(MAX_REF_LEN + 1);
         for (int i = 0; i < MAX_REF_LEN + 1; i++) {
             d.add(new HashMap<>());
         }
 
         //For each reference length there is also a reverse dictionary mapping dictionary offsets to substrings
         //This makes removing dictionary entries much more efficient
-        r = new ArrayList<>();
+        r = new ArrayList<>(MAX_REF_LEN + 1);
         for (int i = 0; i < MAX_REF_LEN + 1; i++) {
             r.add(new HashMap<>());
         }


### PR DESCRIPTION
Things were being written to disk one byte at a time which is really slow. This Turns List<Byte> into byte[] and batch writes it to the output file.

Lists were given no initial capacity. Most could be known or estimated.

Change List:

    The compressed LZ size is generally less than the uncompressed size,
        so I made it default to a capacity of the uncompressed size
    LZ blocks are at most 16 bytes, so I just made it default to that size.
    Instead of remaking a List for every reference block, I just cleared the same one every time.
    I defaulted the uncompressed LZ List to size 1,000,000 (around 1 MB).
        This can be reverted/changed if you think it's too much.
    The List size in LZSSDictionary never changes, so I gave it that initial capacity